### PR TITLE
oisp/client.py Client init | added check for / in base url

### DIFF
--- a/oisp/client.py
+++ b/oisp/client.py
@@ -194,6 +194,9 @@ class Client:
         self.response = None
         # Test connection
         self.get_server_info()
+        # Check if the base_url ende with a / and if so, remove it
+        if self.base_url[-1] == "/":
+            self.base_url = self.base_url[:-1]
 
     def get_headers(self, authorize_as=None, authorize=True):
         """Return a JSON dictionary containing request headers.


### PR DESCRIPTION
Hey Ali,
I added a very simple check for the base_url if the last char is a "/" or not and if so remove the "/" since at the Hackathon at Cloudfest the "/" caused an error. Thats why I already updated the README.md see #14

PS: I remembered to sign my commit  this time ;)